### PR TITLE
fix: menu de contexto das abas sendo coberto pelo WebContentsView

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -221,29 +221,6 @@ body {
     color: #00ccff;
 }
 
-/* Menu de Contexto */
-.context-menu {
-    position: fixed;
-    background: #2a2a2a;
-    border: 1px solid #404040;
-    border-radius: 4px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    z-index: 1500;
-    display: none;
-    min-width: 120px;
-}
-
-.context-option {
-    padding: 8px 12px;
-    color: white;
-    cursor: pointer;
-    transition: background-color 0.2s;
-}
-
-.context-option:hover {
-    background-color: #404040;
-}
-
 /* Conteúdo Principal */
 #main-content {
     display: flex;

--- a/assets/js/preload.js
+++ b/assets/js/preload.js
@@ -30,6 +30,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     findNext: (tabId, query, forward) => ipcRenderer.send("host:find-next", { id: tabId, query, forward }),
     findClose: (tabId) => ipcRenderer.send("host:find-close", { id: tabId }),
     clearTabCache: (tabId) => ipcRenderer.send("host:clear-tab-cache", { id: tabId }),
+    showContextMenu: (tabId, x, y) => ipcRenderer.invoke("show-tab-context-menu", tabId, x, y),
     onLoading: (callback) => ipcRenderer.on("tab:loading", (_e, id, loading) => callback(id, loading)),
     onRecoveryToast: (callback) => ipcRenderer.on("tab:recovery-toast", (_e, id, msg) => callback(id, msg)),
     onFound: (callback) => ipcRenderer.on("tab:found", (_e, id, active, matches) => callback(id, active, matches)),

--- a/assets/js/renderer.js
+++ b/assets/js/renderer.js
@@ -152,21 +152,14 @@ function buildSidebar() {
   }
 }
 
-// --- Menu de contexto das abas ---
+// --- Menu de contexto das abas (nativo via Electron Menu) ---
 function showTabContextMenu(event, tabId) {
   if (!isTabAllowed(tabId)) return;
   event.preventDefault();
   event.stopPropagation();
   document.body.setAttribute("data-current-tab", tabId);
-  currentTabId = tabId; // garante que o "Recarregar" age sobre a aba clicada
-  const menu = document.getElementById("tab-context-menu");
-  menu.style.left = `${event.pageX}px`;
-  menu.style.top = `${event.pageY}px`;
-  menu.style.display = "block";
-}
-function hideTabContextMenu() {
-  const menu = document.getElementById("tab-context-menu");
-  if (menu) menu.style.display = "none";
+  currentTabId = tabId;
+  window.electronAPI?.tabs?.showContextMenu?.(tabId, event.x, event.y);
 }
 function hideAllMenus() {
   document.querySelectorAll(".dropdown-menu").forEach((m) => m.classList.remove("show"));
@@ -229,7 +222,6 @@ function reloadCurrentTab() {
   const tabId = currentTabId || document.body.getAttribute("data-current-tab");
   if (!tabId) return;
   window.electronAPI?.tabs?.reload?.(tabId);
-  hideTabContextMenu();
 }
 function clearAppCache() {
   if (confirm("Isso irá limpar todo o cache e dados de navegação (incluindo logins) e reiniciar a aplicação. Deseja continuar?")) {
@@ -368,7 +360,6 @@ document.addEventListener("DOMContentLoaded", () => {
   // Listeners globais de UI
   document.addEventListener("click", (e) => {
     if (!e.target.closest(".dropdown")) hideAllMenus();
-    if (!e.target.closest("#tab-context-menu")) hideTabContextMenu();
     if (e.target.classList?.contains("modal")) {
       e.target.style.display = "none";
       setOverlay(false);
@@ -393,9 +384,6 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("keep-tabs-active")?.addEventListener("change", toggleKeepTabsActive);
   document.getElementById("app-mode")?.addEventListener("change", toggleAppMode);
 
-  // Menu de contexto das abas
-  document.getElementById("ctx-reload")?.addEventListener("click", reloadCurrentTab);
-
   // Sobre
   document.getElementById("github-link")?.addEventListener("click", (e) => {
     e.preventDefault();
@@ -408,7 +396,6 @@ document.addEventListener("DOMContentLoaded", () => {
     if (findActive) { closeFindBar(); return; }
     hideSettings();
     hideAbout();
-    hideTabContextMenu();
     setOverlay(false);
   });
 

--- a/index.html
+++ b/index.html
@@ -57,11 +57,6 @@
     </div>
   </div>
 
-  <!-- Menu de Contexto das Abas -->
-  <div id="tab-context-menu" class="context-menu">
-    <div class="context-option" id="ctx-reload">Recarregar</div>
-  </div>
-
   <!-- Modal Sobre -->
   <div id="about-modal" class="modal">
     <div class="modal-content">

--- a/modules/ipc-channels.js
+++ b/modules/ipc-channels.js
@@ -18,6 +18,7 @@ module.exports = {
   SAVE_SETTINGS: "save-settings",
   GET_GROK_USER_AGENT: "get-grok-user-agent",
   SHOW_WEBVIEW_CONTEXT_MENU: "show-webview-context-menu",
+  SHOW_TAB_CONTEXT_MENU: "show-tab-context-menu",
 
   // Comandos enviados do menu do processo principal para o renderer
   COMMAND_PREFIX: "command:",

--- a/modules/ipcHandlers.js
+++ b/modules/ipcHandlers.js
@@ -1,5 +1,5 @@
 // modules/ipcHandlers.js
-const { ipcMain, shell } = require("electron");
+const { ipcMain, shell, Menu, MenuItem } = require("electron");
 const Channels = require("./ipc-channels");
 
 const GITHUB_URL = "https://github.com/awilliansd";
@@ -99,6 +99,23 @@ function initializeIpcHandlers(mainWindow, app, settingsManager) {
   ipcMain.removeHandler(Channels.SAVE_SETTINGS);
   ipcMain.handle(Channels.SAVE_SETTINGS, (event, settings) => {
     return settingsManager.saveSettings(settings);
+  });
+
+  // Menu de contexto nativo das abas da sidebar
+  ipcMain.handle(Channels.SHOW_TAB_CONTEXT_MENU, (event, tabId, x, y) => {
+    const windowManager = require("./windowManager");
+    const win = windowManager.getMainWindow();
+    if (!win) return;
+
+    const menu = new Menu();
+    menu.append(new MenuItem({
+      label: "Recarregar",
+      click: () => {
+        win.webContents.send(Channels.RELOAD_TAB, tabId);
+      },
+    }));
+
+    menu.popup({ window: win, x, y });
   });
 
   ipcMain.on(Channels.CLEAR_APP_CACHE, async () => {

--- a/modules/ipcHandlers.test.js
+++ b/modules/ipcHandlers.test.js
@@ -10,7 +10,12 @@ jest.mock('electron', () => ({
   },
   shell: {
     openExternal: jest.fn()
-  }
+  },
+  Menu: jest.fn().mockImplementation(() => ({
+    append: jest.fn(),
+    popup: jest.fn(),
+  })),
+  MenuItem: jest.fn(),
 }));
 
 // Mock dos módulos internos
@@ -75,6 +80,7 @@ describe('ipcHandlers', () => {
       expect(ipcMain.handle).toHaveBeenCalledWith('get-app-version', expect.any(Function));
       expect(ipcMain.handle).toHaveBeenCalledWith('get-settings', expect.any(Function));
       expect(ipcMain.handle).toHaveBeenCalledWith('save-settings', expect.any(Function));
+      expect(ipcMain.handle).toHaveBeenCalledWith('show-tab-context-menu', expect.any(Function));
       
       expect(ipcMain.removeHandler).toHaveBeenCalledWith('get-app-version');
       expect(ipcMain.removeHandler).toHaveBeenCalledWith('get-settings');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-interaction-hub",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-interaction-hub",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "electron-log": "^5.4.4",
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-interaction-hub",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Hub unificado para múltiplos chats de IA",
   "author": "Alessandro Willian",
   "main": "main.js",


### PR DESCRIPTION
Substitui o menu de contexto DOM por Menu.popup() nativo do Electron, que renderiza acima de todas as WebContentsViews.

- Adicionado canal SHOW_TAB_CONTEXT_MENU em ipc-channels.js
- Exposto tabs.showContextMenu() no preload.js
- Criado handler nativo Menu.popup() em ipcHandlers.js
- Removido #tab-context-menu do HTML e CSS
- Atualizado mock de electron nos testes
- Versão 2.2.1